### PR TITLE
If a value is zero, the unit wasn't shown.

### DIFF
--- a/countdown.js
+++ b/countdown.js
@@ -262,63 +262,63 @@ function(module) {
 
 		// if there is a value field, use it directly
 		var value = +ts.value || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setTime(date.getTime() + value);
 			return date;
 		}
 
 		value = +ts.milliseconds || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setMilliseconds(date.getMilliseconds() + value);
 		}
 
 		value = +ts.seconds || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setSeconds(date.getSeconds() + value);
 		}
 
 		value = +ts.minutes || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setMinutes(date.getMinutes() + value);
 		}
 
 		value = +ts.hours || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setHours(date.getHours() + value);
 		}
 
 		value = +ts.weeks || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			value *= DAYS_PER_WEEK;
 		}
 
 		value += +ts.days || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setDate(date.getDate() + value);
 		}
 
 		value = +ts.months || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setMonth(date.getMonth() + value);
 		}
 
 		value = +ts.millennia || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			value *= CENTURIES_PER_MILLENNIUM;
 		}
 
 		value += +ts.centuries || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			value *= DECADES_PER_CENTURY;
 		}
 
 		value += +ts.decades || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			value *= YEARS_PER_DECADE;
 		}
 
 		value += +ts.years || 0;
-		if (value) {
+		if (typeof value === 'number') {
 			date.setFullYear(date.getFullYear() + value);
 		}
 


### PR DESCRIPTION
This fix tests the value type. If it's a number, the unit is added. From my point of view the original behaviour is incorrect because I specifically ask to display that unit, even if it is zero.
